### PR TITLE
chore(Travis): Remove support #18

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,7 +9,6 @@
   "version": "0.1.0",
   "use_pytest": "n",
   "use_black": "n",
-  "use_pypi_deployment_with_travis": "y",
   "add_pyup_badge": "n",
   "command_line_interface": ["Click", "Argparse", "No command-line interface"],
   "create_author_file": "y",


### PR DESCRIPTION
Travis is quite expensive and the free tier is only for a trial.
Continue with GitHub actions for build and deploy.

WIP #18