### PR TITLE
fix(docs): Add readthedocs.yaml config file #40

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+    image: testing
+
+sphinx:
+    builder: html
+    configuration: docs/source/conf.py
+    # fail_on_warning: true
+
+python:
+    version: "3.9"
+    install:
+        - requirements: docs/requirements.txt
+        - method: pip
+          path: .


### PR DESCRIPTION
* I have added a readthedocs.yaml file for config settings required soon
  for document features.
* I have changed readthedocs settings on the website to show the latest
  build.

closes #40