### PR TITLE
fix(git): Comment out on:push:main  #44

### DIFF
--- a/.github/workflows/test_contribution.yaml
+++ b/.github/workflows/test_contribution.yaml
@@ -4,8 +4,8 @@ on:
     pull_request:
         branches: [main]
 
-    push:
-        branches: [main]
+    # push:
+    #     branches: [main]
 
     workflow_dispatch:
 


### PR DESCRIPTION
I have commented out on:push:main, so the workflow does not run twice.
The workflow should only run on:pull_request:main now.

closes #44