### PR TITLE
fix(CHANGELOG): Fix tox.ini and conf.py #43

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ release = "0.9.0"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.todo",

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters = true
 [testenv:docs]
 basepython=python
 changedir=docs/source
-deps=sphinx
+deps= -r{toxinidir}/docs/requirements.txt
 commands=
     sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 


### PR DESCRIPTION
* The CHANGELOG was missing on readthedocs build.
* The cause of the CHANGELOG missing on the docs index was "myst_parser"
  wasn't added to conf.py extensions[].
* Adding "myst_parser" to conf.py extensions caused tox tests to fail.
* [testenv:docs].deps was changed to -r{toxinidir}/docs/requirements.txt
  which solved the problem.

closes #43