### PR TITLE
feat(package): Add Conventional commits msg #15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@
 
 |
 
-**A fork of** cookiecutter-pypackage_
+**A fork of** cookiecutter-pypackage_.
 
 **Currently, this is being updated to meet my specific needs, and perhaps yours.**
 
@@ -48,20 +48,22 @@ Cookiecutter_ template for a Python package.
 * Free software: BSD license
 
 
-**The information below relates to the original package and has not been
-updated yet**
-
-**Notable Fork changes from the Original project so far.**
+**Notable changes from the Original project so far.**
 
 #. Links from the original fork have been updated to point to this repository.
 #. Support for Travis has been removed.
 #. Stale Similar Cookiecutter Templates have been removed.
+#. `Conventional Commits <https://www.conventionalcommits.org/en/v1.0.0/>`_
+   specification custom commit message are now built into the
+   cookiecutter-p3-package project.
+#. Choose to use a `Conventional Commits <https://www.conventionalcommits.org/en/v1.0.0/>`_
+   specification custom commits message in your built package.
 
 Features
 --------
 
 * Testing setup with ``unittest`` and ``python setup.py test`` or ``pytest``.
-* Tox_ testing: Setup to easily test for Python 3.6, 3.7, 3.8.
+* Tox_ testing: Setup to easily test for Python 3.6, 3.7, 3.8 and 3.9.
 * Sphinx_ docs: Documentation ready for generation with, for example, `Read the Docs`_.
 * bump2version_: Pre-configured version bumping with a single command.
 * Auto-release to PyPI_ when you push a new tag to master (optional).

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,5 +12,6 @@
   "add_pyup_badge": "n",
   "command_line_interface": ["Click", "Argparse", "No command-line interface"],
   "create_author_file": "y",
+  "create_conventional_commits_edit_message": "y",
   "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"]
 }

--- a/docs/source/prompts.rst
+++ b/docs/source/prompts.rst
@@ -30,7 +30,7 @@ project_slug
 ~~~~~~~~~~~~
 The namespace of your Python package. This should be Python import-friendly.
 Typically, it is the slugified version of project_name. Note: your PyPi
-project and Travis links will use project_slug, so change those in the
+project will use project_slug, so change those in the
 README afterwards.
 
 project_short_description
@@ -52,20 +52,35 @@ Options
 The following package configuration options set up different features for your
 project.
 
-use_pytest
-    Whether to use `pytest <https://docs.pytest.org/en/latest/>`_
+**use_pytest**
+    Whether to use `pytest <https://docs.pytest.org/en/latest/>`_.
 
-add_pyup_badge
-    Whether to include a `pyup <https://github.com/pyupio/pyup>`_ badge
+**add_pyup_badge**
+    Whether to include a `pyup <https://github.com/pyupio/pyup>`_ badge.
 
-command_line_interface
+**command_line_interface**
     Whether to create a console script using Click. Console script entry point
-    will match the project_slug. Options: ['Click', 'Argparse', 'No command-line interface']
+    will match the project_slug.
+    Options: ['Click', 'Argparse', 'No command-line interface']
 
-create_author_file
-    Whether to create an authors file
+**create_author_file**
+    Whether to create an authors file.
 
-open_source_license
+**create_conventional_commits_edit_message**
+    Whether to use a commit message that helps you adhere to the
+    `Conventional Commits <https://www.conventionalcommits.org/en/v1.0.0/>`_
+    specification.
+
+.. important::
+
+    If you choose yes, don't forget to run the following command after
+    initiating git to let git know you are using a custom template.
+
+    .. code-block:: bash
+
+        git config --local commit.template .github/.git-commit-template.txt
+
+**open_source_license**
     Choose a `license <https://choosealicense.com/>`_. Options:
 
     1. MIT License,
@@ -73,4 +88,4 @@ open_source_license
     3. ISC license,
     4. Apache Software License 2.0,
     5. GNU General Public License v3,
-    6. Not open source]
+    6. Not open source

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -22,3 +22,6 @@ if __name__ == "__main__":
 
     if "Not open source" == "{{ cookiecutter.open_source_license }}":
         remove_file("LICENSE")
+
+    if "{{ cookiecutter.create_conventional_commits_edit_message }}" != "y":
+        remove_file(".github/.git-commit-template.txt")

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -393,3 +393,14 @@ def test_black(cookies, use_black, expected):
         assert ("black" in requirements_path.read()) is expected
         makefile_path = result.project.join('Makefile')
         assert ("black --check" in makefile_path.read()) is expected
+
+def test_bake_without_conventional_commits_message(cookies):
+    with bake_in_temp_dir(
+        cookies, extra_context={"create_conventional_commits_edit_message": "n"}
+    ) as result:
+
+        git_files = [f.basename for f in result.project.join(".github").listdir()]
+        print("git files ", git_files)
+        assert ".git-commit-template.txt" not in git_files
+
+

--- a/{{cookiecutter.project_slug}}/.github/.git-commit-template.txt
+++ b/{{cookiecutter.project_slug}}/.github/.git-commit-template.txt
@@ -1,0 +1,44 @@
+
+# tag(subject):<Description>  #nn being the issue number if it exists
+# (subject): CHANGELOG update groups items with the same subject.
+# |<----   Preferably using up to 50 chars   --->|<--Max of 72 chars-->|
+# Example: docs(style):Added a new reST style guide #42
+
+
+# (Optional) Explain why this change is being made
+# |<----   Try To Limit Each Line to a Maximum Of 72 Characters   ---->|
+# Example: There wasnt a reST style guide.
+
+
+# (Optional) Provide links or keys to any relevant tickets, articles or other resources
+# Example: closes #42
+
+
+# --- COMMIT END ---
+# Tags with ** will be included in the CHANGELOG
+# **   chore    (a chore that needs to be done)
+#      dbg      (changes in debugging code/frameworks; no production code change)
+#      defaults (changes default options)
+# **   docs      (changes to documentation)
+# **   feat     (new feature)
+# **   fix      (bug fix)
+#      hack     (temporary fix to make things move forward; please avoid it)
+#      license  (edits regarding licensing; no production code change)
+# **   perf     (performance improvement)
+# **   refactor (refactoring code)
+# **   style    (formatting, missing semi colons, etc; no code change)
+# **   test     (adding or refactoring tests; no production code change)
+#      version  (version bump/new release; no production code change)
+#      WIP      (Work In Progress; for intermediate commits to keep patches reasonably sized)
+#      jsrXXX   (patches related to the implementation of jsrXXX, where XXX the JSR number)
+#      jdkX     (patches related to supporting jdkX as the host VM, where X the JDK version)
+#
+# --------------------
+# Remember to:
+#   * Capitalize the subject line start
+#   * Use the imperative mood in the subject line
+#   * Do not end the subject line with a period
+#   * Separate subject from body with a blank line
+#   * Use the body to explain what and why vs. how
+#   * Can use multiple lines with "-" or "*" for bullet points in body
+# --------------------


### PR DESCRIPTION
Using a conventional commits message template with guidance on how to
use it will help commit message consistency and allow autogenerated
changelogs.

closes #15