### PR TITLE
fix(version): Change to python-semantic-release #60

### DIFF
--- a/.github/semantic.yaml
+++ b/.github/semantic.yaml
@@ -1,0 +1,32 @@
+# Always validate the PR title AND all the commits
+titleAndCommits: true
+
+# A list of valid scopes
+# scopes:
+#     - CHANGELOG
+#     - scope2
+
+# Allow use of Merge commits (eg on github: "Merge branch 'master'
+# into feature/ride-unicorns").
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowMergeCommits: true
+
+# Allow use of Revert commits (eg on github: "Revert "feat: ride unicorns"")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowRevertCommits: true
+
+# By default types specified in commitizen/conventional-commit-types is used.
+# See: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json
+# You can override the valid types
+types:
+    - build
+    - chore
+    - ci
+    - docs
+    - feat
+    - fix
+    - perf
+    - refactor
+    - revert
+    - style
+    - test

--- a/.github/workflows/semantic_release.yaml
+++ b/.github/workflows/semantic_release.yaml
@@ -1,0 +1,24 @@
+name: Semantic Release
+
+on:
+    pull_request:
+        branches:
+            - main
+        types: [closed]
+
+jobs:
+    release:
+        if: github.event.pull_request.merged == true
+        runs-on: ubuntu-latest
+        concurrency: release
+
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Python Semantic Release
+              uses: relekang/python-semantic-release@master
+              with:
+                  github_token: ${{ secrets.CHANGELOG_UPDATE }}
+                  pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/update-changelog-doc.yaml
+++ b/.github/workflows/update-changelog-doc.yaml
@@ -22,4 +22,15 @@ jobs:
                   ACCESS_TOKEN: ${{secrets.CHANGELOG_UPDATE}}
                   PATH: "docs/source/CHANGELOG-docs.md"
                   COMMIT_MESSAGE: "docs(CHANGELOG): update release notes:docs"
-                  TYPE: "chore:Chore,feat:Feature,fix:Bug Fixes,docs:Documentation,perf:Performance Improvements,refactor:Refactor,style:Styling,test:Tests, WIP:In Progress"
+                  TYPE: "build:Build,\
+                      ci:CI, \
+                      chore:Chore,\
+                      docs:Documentation,\
+                      feat:Feature,\
+                      fix:Bug Fixes,\
+                      perf:Performance Improvements,\
+                      refactor:Refactor,\
+                      revert:Revert, \
+                      style:Styling,\
+                      test:Tests,\
+                      WIP:In Progress"

--- a/.github/workflows/update-changelog-repo.yaml
+++ b/.github/workflows/update-changelog-repo.yaml
@@ -22,4 +22,15 @@ jobs:
                   ACCESS_TOKEN: ${{secrets.CHANGELOG_UPDATE}}
                   PATH: "/CHANGELOG.md"
                   COMMIT_MESSAGE: "docs(CHANGELOG): update release notes:repo"
-                  TYPE: "chore:Chore,feat:Feature,fix:Bug Fixes,docs:Documentation,perf:Performance Improvements,refactor:Refactor,style:Styling,test:Tests, WIP:In Progress"
+                  TYPE: "build:Build,\
+                      ci:CI, \
+                      chore:Chore,\
+                      docs:Documentation,\
+                      feat:Feature,\
+                      fix:Bug Fixes,\
+                      perf:Performance Improvements,\
+                      refactor:Refactor,\
+                      revert:Revert, \
+                      style:Styling,\
+                      test:Tests,\
+                      WIP:In Progress"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,10 @@
 import os
 import sys
 
+# Updated with python-semantic-release
+__version__ = "0.0.0"
+
+
 sys.path.insert(0, os.path.abspath("."))
 
 
@@ -26,9 +30,9 @@ author = "Audrey Roy Greenfeld"
 
 
 # The short X.Y version.
-version = "0.9.0"
+version = __version__
 # The full version, including alpha/beta/rc tags.
-release = "0.9.0"
+release = __version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,9 +2,11 @@ alabaster==0.7.12
 cookiecutter==1.4.0
 furo==2021.8.11b42
 myst-parser==0.15.2
+semver==2.13.0
 Sphinx==4.1.2
 pre-commit==2.14.1
 pytest==5.3.1
 pytest-cookies==0.5.1
+pytest-cov==2.12.1
 tox==3.14.1
-watchdog==0.9.0
+watchdog==2.1.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,13 @@ description-file = README.rst
 [bumpversion:file:setup.py]
 search = version='{current_version}'
 replace = version='{new_version}'
+
+[semantic_release]
+branch =  main
+version_variable = setup.py:__version__, docs/source/conf.py:__version__
+
+major_on_zero = false
+upload_to_pypi = false
+check_build_status = true
+
+commit_subject = build(version): Bump to version-{version}.

--- a/setup.py
+++ b/setup.py
@@ -3,23 +3,27 @@
 
 from setuptools import find_packages, setup
 
+__version__ = "0.0.0"
+
 setup(
-    name="cookiecutter-pypackage",
+    name="cookiecutter-py3-package",
     packages=find_packages(exclude=("tests*", "testing*")),
-    version="0.1.0",
-    description="Cookiecutter template for a Python package",
-    author="Audrey Roy Greenfeld",
+    version=__version__,
+    description="An easy Cookiecutter template for Python 3 Packaging with \
+        continuous delivery using GitHub actions.",
+    author="Mark Sevelj",
     license="BSD",
-    author_email="aroy@alum.mit.edu",
-    url="https://github.com/audreyr/cookiecutter-pypackage",
+    author_email="mark.sevelj@dunwright.com.au",
+    url="https://github.com/imAsparky/cookiecutter-py3-package",
     keywords=[
         "cookiecutter",
+        "Python 3",
         "template",
         "package",
     ],
     python_requires=">=3.6",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 2 - Pre-Alpha",
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Natural Language :: English",
@@ -29,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development",


### PR DESCRIPTION
* Semantic Version updates were not working when a user merged an update
  into the main branch.
* The cause was a misunderstanding with the selected sem-ver package and
  its capabilities.
* Python-semantic-release has been implemented, with a config file and
  the relekang/python-semantic-release@master GitHub action.
* The setup.py, setup.cfg and sphinx conf.py files now use the
  __version__ style recommended by python-semantic-release.
* requirements_dev.txt now includes python-semantic-release for local
  checks using --noop.
* Automatic-Changelog workflows updates match semantic_release.yaml
  config files.

WIP #60