### PR TITLE
feat(issues): Add four custom issue templates #75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,243 +1,278 @@
 # CHANGELOG
 
+<!--next-version-placeholder-->
+
 ## [v0.4.0](https://github.com/imAsparky/cookiecutter-py3-package/releases/tag/v0.4.0) - 2021-09-14 04:21:25
 
 ### Feature
-* **version:** Add pkg GH action sem-ver opt #14 ([#74](https://github.com/imAsparky/cookiecutter-py3-package/issues/74)) ([`f619ab6`](https://github.com/imAsparky/cookiecutter-py3-package/commit/f619ab6e78e5a4b393d7c2098def683eeb368266))
+
+-   **version:** Add pkg GH action sem-ver opt #14 ([#74](https://github.com/imAsparky/cookiecutter-py3-package/issues/74)) ([`f619ab6`](https://github.com/imAsparky/cookiecutter-py3-package/commit/f619ab6e78e5a4b393d7c2098def683eeb368266))
 
 ### Documentation
-* **CHANGELOG:** Update release notes:repo ([`6796ac9`](https://github.com/imAsparky/cookiecutter-py3-package/commit/6796ac974538acdc9fb868d58f67186a11d2f71d))
+
+-   **CHANGELOG:** Update release notes:repo ([`6796ac9`](https://github.com/imAsparky/cookiecutter-py3-package/commit/6796ac974538acdc9fb868d58f67186a11d2f71d))
 
 ### Build
 
-- version:
-  - Bump to version - 0.4.0. ([6e86af3](https://github.com/imAsparky/cookiecutter-py3-package/commit/6e86af35036c12f093ee63d3906be87c3d7d275d))
+-   version:
+    -   Bump to version - 0.4.0. ([6e86af3](https://github.com/imAsparky/cookiecutter-py3-package/commit/6e86af35036c12f093ee63d3906be87c3d7d275d))
 
 ### Feature
 
-- version:
-  - Add pkg GH action sem-ver opt #14 (#74) ([f619ab6](https://github.com/imAsparky/cookiecutter-py3-package/commit/f619ab6e78e5a4b393d7c2098def683eeb368266)) ([#74](https://github.com/imAsparky/cookiecutter-py3-package/pull/74))
+-   version:
+    -   Add pkg GH action sem-ver opt #14 (#74) ([f619ab6](https://github.com/imAsparky/cookiecutter-py3-package/commit/f619ab6e78e5a4b393d7c2098def683eeb368266)) ([#74](https://github.com/imAsparky/cookiecutter-py3-package/pull/74))
 
 ## [v0.3.0](https://github.com/imAsparky/cookiecutter-py3-package/releases/tag/v0.3.0) - 2021-09-14 00:56:09
 
 ### Feature
-* **tests:** Add GH action for autotesting #16 ([#73](https://github.com/imAsparky/cookiecutter-py3-package/issues/73)) ([`a49b767`](https://github.com/imAsparky/cookiecutter-py3-package/commit/a49b767f9baba25f091f5e948458dd995fe83bef))
+
+-   **tests:** Add GH action for autotesting #16 ([#73](https://github.com/imAsparky/cookiecutter-py3-package/issues/73)) ([`a49b767`](https://github.com/imAsparky/cookiecutter-py3-package/commit/a49b767f9baba25f091f5e948458dd995fe83bef))
 
 ### Documentation
-* **CHANGELOG:** Update release notes:docs ([`c12e2f5`](https://github.com/imAsparky/cookiecutter-py3-package/commit/c12e2f53c2360d5b2eaf15666896a40578df1aca))
-* **CHANGELOG:** Update release notes:repo ([`19dedf4`](https://github.com/imAsparky/cookiecutter-py3-package/commit/19dedf443bf662efd407e7b47902ab8afaea96e5))
+
+-   **CHANGELOG:** Update release notes:docs ([`c12e2f5`](https://github.com/imAsparky/cookiecutter-py3-package/commit/c12e2f53c2360d5b2eaf15666896a40578df1aca))
+-   **CHANGELOG:** Update release notes:repo ([`19dedf4`](https://github.com/imAsparky/cookiecutter-py3-package/commit/19dedf443bf662efd407e7b47902ab8afaea96e5))
 
 ### Build
 
-- version:
-  - Bump to version - 0.3.0. ([adbf1bb](https://github.com/imAsparky/cookiecutter-py3-package/commit/adbf1bb69e62e08d998b016c40ba387b7fc008a1))
+-   version:
+    -   Bump to version - 0.3.0. ([adbf1bb](https://github.com/imAsparky/cookiecutter-py3-package/commit/adbf1bb69e62e08d998b016c40ba387b7fc008a1))
 
 ### Feature
 
-- tests:
-  - Add GH action for autotesting #16 (#73) ([a49b767](https://github.com/imAsparky/cookiecutter-py3-package/commit/a49b767f9baba25f091f5e948458dd995fe83bef)) ([#73](https://github.com/imAsparky/cookiecutter-py3-package/pull/73))
+-   tests:
+    -   Add GH action for autotesting #16 (#73) ([a49b767](https://github.com/imAsparky/cookiecutter-py3-package/commit/a49b767f9baba25f091f5e948458dd995fe83bef)) ([#73](https://github.com/imAsparky/cookiecutter-py3-package/pull/73))
 
 ## [v0.2.0](https://github.com/imAsparky/cookiecutter-py3-package/releases/tag/v0.2.0) - 2021-09-13 09:17:34
 
 ### Feature
-* **CHANGELOG:** Add auto update opt to pkge #12 ([#70](https://github.com/imAsparky/cookiecutter-py3-package/issues/70)) ([`5e24e40`](https://github.com/imAsparky/cookiecutter-py3-package/commit/5e24e403ecc39b64bbb963570bac7d1d2426a8d0))
+
+-   **CHANGELOG:** Add auto update opt to pkge #12 ([#70](https://github.com/imAsparky/cookiecutter-py3-package/issues/70)) ([`5e24e40`](https://github.com/imAsparky/cookiecutter-py3-package/commit/5e24e403ecc39b64bbb963570bac7d1d2426a8d0))
 
 ### Documentation
-* **CHANGELOG:** Update release notes:repo ([`2fba5e5`](https://github.com/imAsparky/cookiecutter-py3-package/commit/2fba5e5a840efd90ba8a443b529398481a461b13))
+
+-   **CHANGELOG:** Update release notes:repo ([`2fba5e5`](https://github.com/imAsparky/cookiecutter-py3-package/commit/2fba5e5a840efd90ba8a443b529398481a461b13))
 
 ### Build
 
-- version:
-  - Bump to version - 0.2.0. ([5eda4ea](https://github.com/imAsparky/cookiecutter-py3-package/commit/5eda4eabedb87b78fb188a9db6db40de912891b2))
+-   version:
+    -   Bump to version - 0.2.0. ([5eda4ea](https://github.com/imAsparky/cookiecutter-py3-package/commit/5eda4eabedb87b78fb188a9db6db40de912891b2))
 
 ### Feature
 
-- CHANGELOG:
-  - Add auto update opt to pkge #12 (#70) ([5e24e40](https://github.com/imAsparky/cookiecutter-py3-package/commit/5e24e403ecc39b64bbb963570bac7d1d2426a8d0)) ([#70](https://github.com/imAsparky/cookiecutter-py3-package/pull/70))
+-   CHANGELOG:
+    -   Add auto update opt to pkge #12 (#70) ([5e24e40](https://github.com/imAsparky/cookiecutter-py3-package/commit/5e24e403ecc39b64bbb963570bac7d1d2426a8d0)) ([#70](https://github.com/imAsparky/cookiecutter-py3-package/pull/70))
 
 ## [v0.1.1](https://github.com/imAsparky/cookiecutter-py3-package/releases/tag/v0.1.1) - 2021-09-13 04:36:05
 
 ### Fix
-* **version:** Update commit_subject #60 ([#68](https://github.com/imAsparky/cookiecutter-py3-package/issues/68)) ([`977acd1`](https://github.com/imAsparky/cookiecutter-py3-package/commit/977acd12519ddf6c03800fd0d78edf93e7c54cb7))
+
+-   **version:** Update commit_subject #60 ([#68](https://github.com/imAsparky/cookiecutter-py3-package/issues/68)) ([`977acd1`](https://github.com/imAsparky/cookiecutter-py3-package/commit/977acd12519ddf6c03800fd0d78edf93e7c54cb7))
 
 ### Documentation
-* **CHANGELOG:** Update release notes:docs ([`9d33ebc`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9d33ebc94a18177db6f00b003b4a05dfa3573190))
-* **CHANGELOG:** Update release notes:repo ([`7c5630e`](https://github.com/imAsparky/cookiecutter-py3-package/commit/7c5630e982ab2482867e9a7777da624c55ecf576))
+
+-   **CHANGELOG:** Update release notes:docs ([`9d33ebc`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9d33ebc94a18177db6f00b003b4a05dfa3573190))
+-   **CHANGELOG:** Update release notes:repo ([`7c5630e`](https://github.com/imAsparky/cookiecutter-py3-package/commit/7c5630e982ab2482867e9a7777da624c55ecf576))
 
 ### Build
 
-- version:
-  - Bump to version - 0.1.1. ([23b10d1](https://github.com/imAsparky/cookiecutter-py3-package/commit/23b10d12f12cf462c2b949166b4b96b77247164f))
+-   version:
+    -   Bump to version - 0.1.1. ([23b10d1](https://github.com/imAsparky/cookiecutter-py3-package/commit/23b10d12f12cf462c2b949166b4b96b77247164f))
 
 ### Bug Fixes
 
-- version:
-  - Update commit_subject #60 (#68) ([977acd1](https://github.com/imAsparky/cookiecutter-py3-package/commit/977acd12519ddf6c03800fd0d78edf93e7c54cb7)) ([#68](https://github.com/imAsparky/cookiecutter-py3-package/pull/68))
+-   version:
+    -   Update commit_subject #60 (#68) ([977acd1](https://github.com/imAsparky/cookiecutter-py3-package/commit/977acd12519ddf6c03800fd0d78edf93e7c54cb7)) ([#68](https://github.com/imAsparky/cookiecutter-py3-package/pull/68))
 
 ## [v0.1.0](https://github.com/imAsparky/cookiecutter-py3-package/releases/tag/v0.1.0) - 2021-09-13 03:58:08
 
 ### Feature
-* **package:** Add Conventional commits msg #15 ([#59](https://github.com/imAsparky/cookiecutter-py3-package/issues/59)) ([`9ce47dc`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9ce47dc73327bdb39d49e5e2074f1320e71d2285))
-* **pre-commit:** Add to pre-commit to GH #31 ([`bf25e6c`](https://github.com/imAsparky/cookiecutter-py3-package/commit/bf25e6cf327670a6e7a38e1464de74a25e447205))
-* **test:** Add GH action to test all contribs #10 ([`9f0787d`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9f0787d7403429186948a38e4b33a1ea8c66ab71))
-* **docs:** Add automatic changelog #8 ([`d14487a`](https://github.com/imAsparky/cookiecutter-py3-package/commit/d14487aa3f3c190a1720884e1c875bdca055cb7d))
-* **docs:** Add automatic changelog #8 ([`0160b52`](https://github.com/imAsparky/cookiecutter-py3-package/commit/0160b52a0a623cc48c8400a5700b1a7460cb6812))
-* **quality:** Add code quality scan and badge #5 ([`fb8fe81`](https://github.com/imAsparky/cookiecutter-py3-package/commit/fb8fe81f4d9439e78a33b00babfa2ab3a7ae380b))
-* **git:** Add pre-commit and sane tests #3 ([`83a8804`](https://github.com/imAsparky/cookiecutter-py3-package/commit/83a88044bfb0ce44e54eb05943f2eb2c4282d195))
-* **git:** Add conventional commits template #2 ([`d808d8e`](https://github.com/imAsparky/cookiecutter-py3-package/commit/d808d8ef08ca158f98bf5a302062f13ab503ab31))
-* **git:** Add additional issue templates #1 ([`6f5c9da`](https://github.com/imAsparky/cookiecutter-py3-package/commit/6f5c9da926b158d2116db2cee3f1bf3ac459c86b))
+
+-   **package:** Add Conventional commits msg #15 ([#59](https://github.com/imAsparky/cookiecutter-py3-package/issues/59)) ([`9ce47dc`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9ce47dc73327bdb39d49e5e2074f1320e71d2285))
+-   **pre-commit:** Add to pre-commit to GH #31 ([`bf25e6c`](https://github.com/imAsparky/cookiecutter-py3-package/commit/bf25e6cf327670a6e7a38e1464de74a25e447205))
+-   **test:** Add GH action to test all contribs #10 ([`9f0787d`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9f0787d7403429186948a38e4b33a1ea8c66ab71))
+-   **docs:** Add automatic changelog #8 ([`d14487a`](https://github.com/imAsparky/cookiecutter-py3-package/commit/d14487aa3f3c190a1720884e1c875bdca055cb7d))
+-   **docs:** Add automatic changelog #8 ([`0160b52`](https://github.com/imAsparky/cookiecutter-py3-package/commit/0160b52a0a623cc48c8400a5700b1a7460cb6812))
+-   **quality:** Add code quality scan and badge #5 ([`fb8fe81`](https://github.com/imAsparky/cookiecutter-py3-package/commit/fb8fe81f4d9439e78a33b00babfa2ab3a7ae380b))
+-   **git:** Add pre-commit and sane tests #3 ([`83a8804`](https://github.com/imAsparky/cookiecutter-py3-package/commit/83a88044bfb0ce44e54eb05943f2eb2c4282d195))
+-   **git:** Add conventional commits template #2 ([`d808d8e`](https://github.com/imAsparky/cookiecutter-py3-package/commit/d808d8ef08ca158f98bf5a302062f13ab503ab31))
+-   **git:** Add additional issue templates #1 ([`6f5c9da`](https://github.com/imAsparky/cookiecutter-py3-package/commit/6f5c9da926b158d2116db2cee3f1bf3ac459c86b))
 
 ### Fix
-* **version:** Add a pre-tested if: condition #60 ([#67](https://github.com/imAsparky/cookiecutter-py3-package/issues/67)) ([`d227bea`](https://github.com/imAsparky/cookiecutter-py3-package/commit/d227bea0eca9b5239438ff61491c2559f6b440c0))
-* **version:** Del manual job & fix concurrency #60 ([#66](https://github.com/imAsparky/cookiecutter-py3-package/issues/66)) ([`6e1c1ca`](https://github.com/imAsparky/cookiecutter-py3-package/commit/6e1c1cadbe20755efb1911768343e6050a293469))
-* **version:** Change to chk_bld_stat false #60 ([#63](https://github.com/imAsparky/cookiecutter-py3-package/issues/63)) ([`cc63fa9`](https://github.com/imAsparky/cookiecutter-py3-package/commit/cc63fa996a00e52c4c91ffcc55eb3056fe1c678f))
-* **version:** Change to python-semantic-release #60 ([#62](https://github.com/imAsparky/cookiecutter-py3-package/issues/62)) ([`83d8d06`](https://github.com/imAsparky/cookiecutter-py3-package/commit/83d8d06ef0f0bee22dc90e4abd32e26ba21bcba6))
-* **version:** Change to python-semantic-release #60 ([#61](https://github.com/imAsparky/cookiecutter-py3-package/issues/61)) ([`88c55f3`](https://github.com/imAsparky/cookiecutter-py3-package/commit/88c55f3755993a9a2a459d9ae367fa39b81fea50))
-* **pre-com:** Fix pre-commit errors #50 ([#51](https://github.com/imAsparky/cookiecutter-py3-package/issues/51)) ([`9360c7f`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9360c7fe47a3e79ae421c5e43ce330414203b2b1))
-* **CHANGELOG:** Fix tox.ini and conf.py #43 ([#47](https://github.com/imAsparky/cookiecutter-py3-package/issues/47)) ([`c7ead74`](https://github.com/imAsparky/cookiecutter-py3-package/commit/c7ead747409c6b1997e2524fefd261f7259d0274))
-* **git:** Comment out on:push:main  #44 ([#45](https://github.com/imAsparky/cookiecutter-py3-package/issues/45)) ([`3631126`](https://github.com/imAsparky/cookiecutter-py3-package/commit/3631126832b3724859a2cfb58a834205c5948567))
-* **docs:** Add readthedocs.yaml config file #40 ([#42](https://github.com/imAsparky/cookiecutter-py3-package/issues/42)) ([`bc14391`](https://github.com/imAsparky/cookiecutter-py3-package/commit/bc14391f508c585aa8a29f00150c75e4823bc4a0))
-* **git:** Remove test for py3.10 #26 ([`e5fdef2`](https://github.com/imAsparky/cookiecutter-py3-package/commit/e5fdef216b7adf4c0759d85fc2b90a733d2f4426))
+
+-   **version:** Add a pre-tested if: condition #60 ([#67](https://github.com/imAsparky/cookiecutter-py3-package/issues/67)) ([`d227bea`](https://github.com/imAsparky/cookiecutter-py3-package/commit/d227bea0eca9b5239438ff61491c2559f6b440c0))
+-   **version:** Del manual job & fix concurrency #60 ([#66](https://github.com/imAsparky/cookiecutter-py3-package/issues/66)) ([`6e1c1ca`](https://github.com/imAsparky/cookiecutter-py3-package/commit/6e1c1cadbe20755efb1911768343e6050a293469))
+-   **version:** Change to chk_bld_stat false #60 ([#63](https://github.com/imAsparky/cookiecutter-py3-package/issues/63)) ([`cc63fa9`](https://github.com/imAsparky/cookiecutter-py3-package/commit/cc63fa996a00e52c4c91ffcc55eb3056fe1c678f))
+-   **version:** Change to python-semantic-release #60 ([#62](https://github.com/imAsparky/cookiecutter-py3-package/issues/62)) ([`83d8d06`](https://github.com/imAsparky/cookiecutter-py3-package/commit/83d8d06ef0f0bee22dc90e4abd32e26ba21bcba6))
+-   **version:** Change to python-semantic-release #60 ([#61](https://github.com/imAsparky/cookiecutter-py3-package/issues/61)) ([`88c55f3`](https://github.com/imAsparky/cookiecutter-py3-package/commit/88c55f3755993a9a2a459d9ae367fa39b81fea50))
+-   **pre-com:** Fix pre-commit errors #50 ([#51](https://github.com/imAsparky/cookiecutter-py3-package/issues/51)) ([`9360c7f`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9360c7fe47a3e79ae421c5e43ce330414203b2b1))
+-   **CHANGELOG:** Fix tox.ini and conf.py #43 ([#47](https://github.com/imAsparky/cookiecutter-py3-package/issues/47)) ([`c7ead74`](https://github.com/imAsparky/cookiecutter-py3-package/commit/c7ead747409c6b1997e2524fefd261f7259d0274))
+-   **git:** Comment out on:push:main #44 ([#45](https://github.com/imAsparky/cookiecutter-py3-package/issues/45)) ([`3631126`](https://github.com/imAsparky/cookiecutter-py3-package/commit/3631126832b3724859a2cfb58a834205c5948567))
+-   **docs:** Add readthedocs.yaml config file #40 ([#42](https://github.com/imAsparky/cookiecutter-py3-package/issues/42)) ([`bc14391`](https://github.com/imAsparky/cookiecutter-py3-package/commit/bc14391f508c585aa8a29f00150c75e4823bc4a0))
+-   **git:** Remove test for py3.10 #26 ([`e5fdef2`](https://github.com/imAsparky/cookiecutter-py3-package/commit/e5fdef216b7adf4c0759d85fc2b90a733d2f4426))
 
 ### Documentation
-* **CHANGELOG:** Update release notes:docs ([`04df834`](https://github.com/imAsparky/cookiecutter-py3-package/commit/04df834419874661dabbdf4b0add87c09ec6d7ef))
-* **CHANGELOG:** Update release notes:repo ([`47c5852`](https://github.com/imAsparky/cookiecutter-py3-package/commit/47c58522b907b3dc035c544168340175ea459886))
-* **CHANGELOG:** Update release notes:repo ([`6b06a18`](https://github.com/imAsparky/cookiecutter-py3-package/commit/6b06a1819236469a904e1da3423a65a0e5900a1a))
-* **CHANGELOG:** Update release notes:docs ([`efe548a`](https://github.com/imAsparky/cookiecutter-py3-package/commit/efe548ab884c2003d85fc32b1cc68214d9958080))
-* **CHANGELOG:** Update release notes:repo ([`26c68b1`](https://github.com/imAsparky/cookiecutter-py3-package/commit/26c68b1a81b782f656edcf120b3e2c47dec319cb))
-* **CHANGELOG:** Update release notes:docs ([`f1990bf`](https://github.com/imAsparky/cookiecutter-py3-package/commit/f1990bf0f297e58c4afeb2d5f8a3dc62022b478f))
-* **CHANGELOG:** Update release notes:repo ([`ce3f5b9`](https://github.com/imAsparky/cookiecutter-py3-package/commit/ce3f5b97dc0ab858c7171b7bf27a9a714ff8288f))
-* **codes:** Add code of conduct #56 ([#58](https://github.com/imAsparky/cookiecutter-py3-package/issues/58)) ([`b69c126`](https://github.com/imAsparky/cookiecutter-py3-package/commit/b69c1269178d77cee55983992b5a22737197d8b9))
-* **README:** Add pre-commit badge #54 ([#55](https://github.com/imAsparky/cookiecutter-py3-package/issues/55)) ([`08450af`](https://github.com/imAsparky/cookiecutter-py3-package/commit/08450af653d7b175a0327f51e5aaac7643f422c0))
-* **tutorial:** Fix broken pypi checklist link #37 ([#53](https://github.com/imAsparky/cookiecutter-py3-package/issues/53)) ([`f6ec351`](https://github.com/imAsparky/cookiecutter-py3-package/commit/f6ec3518368078b34d25293494b3332027ccb37b))
-* **CHANGELOG:** Update release notes:docs ([`1cd4d23`](https://github.com/imAsparky/cookiecutter-py3-package/commit/1cd4d235c661c393d06d8cb6dea59b0aa5c55488))
-* **CHANGELOG:** Update release notes:repo ([`5956b9e`](https://github.com/imAsparky/cookiecutter-py3-package/commit/5956b9ed0e09a5cc21c5827fad977a6c59eebc19))
-* **CHANGELOG:** Update release notes:docs ([`41d893e`](https://github.com/imAsparky/cookiecutter-py3-package/commit/41d893ee4dbb49639f17ff09101fab2283c2cfd2))
-* **CHANGELOG:** Update release notes:repo ([`c76282b`](https://github.com/imAsparky/cookiecutter-py3-package/commit/c76282bf2af20497af9d7b2b744c976674d5a4fa))
-* **CHANGELOG:** Update release notes:docs ([`2a022bb`](https://github.com/imAsparky/cookiecutter-py3-package/commit/2a022bb05e0db8e017da0bfc048210bbc809351a))
-* **CHANGELOG:** Update release notes:repo ([`57511fd`](https://github.com/imAsparky/cookiecutter-py3-package/commit/57511fd370af355a902c7a488225fa1a11ba3da5))
-* **CHANGELOG:** Add to the documentation #43 ([#46](https://github.com/imAsparky/cookiecutter-py3-package/issues/46)) ([`4a4c643`](https://github.com/imAsparky/cookiecutter-py3-package/commit/4a4c6432c5fabee769119baa7b7c3a859ee53b4e))
-* **logo:** Create and add logo to README #38 ([#41](https://github.com/imAsparky/cookiecutter-py3-package/issues/41)) ([`0ca1adb`](https://github.com/imAsparky/cookiecutter-py3-package/commit/0ca1adb6181138de7b6ccf06fa5984d2c693a169))
-* **update:** Links->cookiecutter-py3-package #20 ([#39](https://github.com/imAsparky/cookiecutter-py3-package/issues/39)) ([`7522aa4`](https://github.com/imAsparky/cookiecutter-py3-package/commit/7522aa4014eda677ec28bbd8154906f69afa8811))
-* **CHANGELOG:** Update release notes:repo ([`3656632`](https://github.com/imAsparky/cookiecutter-py3-package/commit/365663217187b5145176a3a75c1fd71a2caba67f))
-* **structure:** Update to newer sphinx style #34 ([`6f76c4e`](https://github.com/imAsparky/cookiecutter-py3-package/commit/6f76c4ead0bb70be7f9630a0fb12ab8f6297bf7d))
-* **CHANGELOG:** Update release notes:repo ([`4eac58b`](https://github.com/imAsparky/cookiecutter-py3-package/commit/4eac58b18a5f2621bc0c5e671568d77dcade4485))
-* **README:** Add to list of notable changes ([#24](https://github.com/imAsparky/cookiecutter-py3-package/issues/24)) ([`5db0139`](https://github.com/imAsparky/cookiecutter-py3-package/commit/5db0139e3c21190b3d2085d3c4947beeac2fea25))
-* **CHANGELOG:** Update release notes:repo ([`eef147a`](https://github.com/imAsparky/cookiecutter-py3-package/commit/eef147a18740dfa10bdde71455420be74dcc7a6c))
-* **fork:** Update to indicate this fork #20 ([`f287b06`](https://github.com/imAsparky/cookiecutter-py3-package/commit/f287b06c8bf40262728bfe2dfe5d542200d0b2ba))
-* **CHANGELOG:** Update release notes:repo ([`9cf4777`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9cf477705b51d9f3490daee26198b1ec859f6cbc))
-* **README:** Remove support for Travis CI #18 ([`0dd88fa`](https://github.com/imAsparky/cookiecutter-py3-package/commit/0dd88fa56d5646caddd54828a2640fa96379d0af))
-* **CHANGELOG:** Update release notes:repo ([`9334b47`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9334b472977b55eea4eb581b4668b82efec6f4eb))
-* **CHANGELOG:** Update release notes:repo ([`cd1f5d9`](https://github.com/imAsparky/cookiecutter-py3-package/commit/cd1f5d967a4422c39b7e1db2f69c9b4d288ab7b3))
-* **CHANGELOG:** Update release notes:repo ([`1dfd294`](https://github.com/imAsparky/cookiecutter-py3-package/commit/1dfd294d6b45a7f4a4be5e75b9b1565a70089a09))
-* **CHANGELOG:** Update release notes:repo ([`77a0834`](https://github.com/imAsparky/cookiecutter-py3-package/commit/77a0834945d67dad7ec7c219d5ead01b7d3e774d))
-* **CHANGELOG:** Update release notes:repo ([`e8207b3`](https://github.com/imAsparky/cookiecutter-py3-package/commit/e8207b3325d307af5303d0e5deef82d005833acf))
-* **README:** Update to reflect this fork #4 ([`e592c57`](https://github.com/imAsparky/cookiecutter-py3-package/commit/e592c5750e36aff5b8486e0324e8778510498d7c))
+
+-   **CHANGELOG:** Update release notes:docs ([`04df834`](https://github.com/imAsparky/cookiecutter-py3-package/commit/04df834419874661dabbdf4b0add87c09ec6d7ef))
+-   **CHANGELOG:** Update release notes:repo ([`47c5852`](https://github.com/imAsparky/cookiecutter-py3-package/commit/47c58522b907b3dc035c544168340175ea459886))
+-   **CHANGELOG:** Update release notes:repo ([`6b06a18`](https://github.com/imAsparky/cookiecutter-py3-package/commit/6b06a1819236469a904e1da3423a65a0e5900a1a))
+-   **CHANGELOG:** Update release notes:docs ([`efe548a`](https://github.com/imAsparky/cookiecutter-py3-package/commit/efe548ab884c2003d85fc32b1cc68214d9958080))
+-   **CHANGELOG:** Update release notes:repo ([`26c68b1`](https://github.com/imAsparky/cookiecutter-py3-package/commit/26c68b1a81b782f656edcf120b3e2c47dec319cb))
+-   **CHANGELOG:** Update release notes:docs ([`f1990bf`](https://github.com/imAsparky/cookiecutter-py3-package/commit/f1990bf0f297e58c4afeb2d5f8a3dc62022b478f))
+-   **CHANGELOG:** Update release notes:repo ([`ce3f5b9`](https://github.com/imAsparky/cookiecutter-py3-package/commit/ce3f5b97dc0ab858c7171b7bf27a9a714ff8288f))
+-   **codes:** Add code of conduct #56 ([#58](https://github.com/imAsparky/cookiecutter-py3-package/issues/58)) ([`b69c126`](https://github.com/imAsparky/cookiecutter-py3-package/commit/b69c1269178d77cee55983992b5a22737197d8b9))
+-   **README:** Add pre-commit badge #54 ([#55](https://github.com/imAsparky/cookiecutter-py3-package/issues/55)) ([`08450af`](https://github.com/imAsparky/cookiecutter-py3-package/commit/08450af653d7b175a0327f51e5aaac7643f422c0))
+-   **tutorial:** Fix broken pypi checklist link #37 ([#53](https://github.com/imAsparky/cookiecutter-py3-package/issues/53)) ([`f6ec351`](https://github.com/imAsparky/cookiecutter-py3-package/commit/f6ec3518368078b34d25293494b3332027ccb37b))
+-   **CHANGELOG:** Update release notes:docs ([`1cd4d23`](https://github.com/imAsparky/cookiecutter-py3-package/commit/1cd4d235c661c393d06d8cb6dea59b0aa5c55488))
+-   **CHANGELOG:** Update release notes:repo ([`5956b9e`](https://github.com/imAsparky/cookiecutter-py3-package/commit/5956b9ed0e09a5cc21c5827fad977a6c59eebc19))
+-   **CHANGELOG:** Update release notes:docs ([`41d893e`](https://github.com/imAsparky/cookiecutter-py3-package/commit/41d893ee4dbb49639f17ff09101fab2283c2cfd2))
+-   **CHANGELOG:** Update release notes:repo ([`c76282b`](https://github.com/imAsparky/cookiecutter-py3-package/commit/c76282bf2af20497af9d7b2b744c976674d5a4fa))
+-   **CHANGELOG:** Update release notes:docs ([`2a022bb`](https://github.com/imAsparky/cookiecutter-py3-package/commit/2a022bb05e0db8e017da0bfc048210bbc809351a))
+-   **CHANGELOG:** Update release notes:repo ([`57511fd`](https://github.com/imAsparky/cookiecutter-py3-package/commit/57511fd370af355a902c7a488225fa1a11ba3da5))
+-   **CHANGELOG:** Add to the documentation #43 ([#46](https://github.com/imAsparky/cookiecutter-py3-package/issues/46)) ([`4a4c643`](https://github.com/imAsparky/cookiecutter-py3-package/commit/4a4c6432c5fabee769119baa7b7c3a859ee53b4e))
+-   **logo:** Create and add logo to README #38 ([#41](https://github.com/imAsparky/cookiecutter-py3-package/issues/41)) ([`0ca1adb`](https://github.com/imAsparky/cookiecutter-py3-package/commit/0ca1adb6181138de7b6ccf06fa5984d2c693a169))
+-   **update:** Links->cookiecutter-py3-package #20 ([#39](https://github.com/imAsparky/cookiecutter-py3-package/issues/39)) ([`7522aa4`](https://github.com/imAsparky/cookiecutter-py3-package/commit/7522aa4014eda677ec28bbd8154906f69afa8811))
+-   **CHANGELOG:** Update release notes:repo ([`3656632`](https://github.com/imAsparky/cookiecutter-py3-package/commit/365663217187b5145176a3a75c1fd71a2caba67f))
+-   **structure:** Update to newer sphinx style #34 ([`6f76c4e`](https://github.com/imAsparky/cookiecutter-py3-package/commit/6f76c4ead0bb70be7f9630a0fb12ab8f6297bf7d))
+-   **CHANGELOG:** Update release notes:repo ([`4eac58b`](https://github.com/imAsparky/cookiecutter-py3-package/commit/4eac58b18a5f2621bc0c5e671568d77dcade4485))
+-   **README:** Add to list of notable changes ([#24](https://github.com/imAsparky/cookiecutter-py3-package/issues/24)) ([`5db0139`](https://github.com/imAsparky/cookiecutter-py3-package/commit/5db0139e3c21190b3d2085d3c4947beeac2fea25))
+-   **CHANGELOG:** Update release notes:repo ([`eef147a`](https://github.com/imAsparky/cookiecutter-py3-package/commit/eef147a18740dfa10bdde71455420be74dcc7a6c))
+-   **fork:** Update to indicate this fork #20 ([`f287b06`](https://github.com/imAsparky/cookiecutter-py3-package/commit/f287b06c8bf40262728bfe2dfe5d542200d0b2ba))
+-   **CHANGELOG:** Update release notes:repo ([`9cf4777`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9cf477705b51d9f3490daee26198b1ec859f6cbc))
+-   **README:** Remove support for Travis CI #18 ([`0dd88fa`](https://github.com/imAsparky/cookiecutter-py3-package/commit/0dd88fa56d5646caddd54828a2640fa96379d0af))
+-   **CHANGELOG:** Update release notes:repo ([`9334b47`](https://github.com/imAsparky/cookiecutter-py3-package/commit/9334b472977b55eea4eb581b4668b82efec6f4eb))
+-   **CHANGELOG:** Update release notes:repo ([`cd1f5d9`](https://github.com/imAsparky/cookiecutter-py3-package/commit/cd1f5d967a4422c39b7e1db2f69c9b4d288ab7b3))
+-   **CHANGELOG:** Update release notes:repo ([`1dfd294`](https://github.com/imAsparky/cookiecutter-py3-package/commit/1dfd294d6b45a7f4a4be5e75b9b1565a70089a09))
+-   **CHANGELOG:** Update release notes:repo ([`77a0834`](https://github.com/imAsparky/cookiecutter-py3-package/commit/77a0834945d67dad7ec7c219d5ead01b7d3e774d))
+-   **CHANGELOG:** Update release notes:repo ([`e8207b3`](https://github.com/imAsparky/cookiecutter-py3-package/commit/e8207b3325d307af5303d0e5deef82d005833acf))
+-   **README:** Update to reflect this fork #4 ([`e592c57`](https://github.com/imAsparky/cookiecutter-py3-package/commit/e592c5750e36aff5b8486e0324e8778510498d7c))
 
 ### Build
 
-- version:
-  - Bump to version-0.1.0. ([dbcbc2f](https://github.com/imAsparky/cookiecutter-py3-package/commit/dbcbc2f5eb46b3751aedc2781097aa591f0f5eac))
+-   version:
+    -   Bump to version-0.1.0. ([dbcbc2f](https://github.com/imAsparky/cookiecutter-py3-package/commit/dbcbc2f5eb46b3751aedc2781097aa591f0f5eac))
 
 ### Chore
 
-- version:
-  - Add workflow_dispatch #60  (#64) ([1df725e](https://github.com/imAsparky/cookiecutter-py3-package/commit/1df725ed6073cf5e690f8b70749a30baede92dd1)) ([#64](https://github.com/imAsparky/cookiecutter-py3-package/pull/64))
+-   version:
 
-- pre-commit:
-  - Weekly pre-commit autoupdate (#52) ([1cec5ce](https://github.com/imAsparky/cookiecutter-py3-package/commit/1cec5ce9c4db54a2945690906ead6a3f4fd1f420)) ([#52](https://github.com/imAsparky/cookiecutter-py3-package/pull/52))
+    -   Add workflow_dispatch #60 (#64) ([1df725e](https://github.com/imAsparky/cookiecutter-py3-package/commit/1df725ed6073cf5e690f8b70749a30baede92dd1)) ([#64](https://github.com/imAsparky/cookiecutter-py3-package/pull/64))
 
-- git:
-  - Add vscode workspace folder .gitignore ([c000227](https://github.com/imAsparky/cookiecutter-py3-package/commit/c00022746f83c123ec441bdd010fdd06e8f34b58))
-  - Add project folders to .gitignore ([4847e57](https://github.com/imAsparky/cookiecutter-py3-package/commit/4847e574c6b978a3aab14313b12a74d1c879dcd6))
+-   pre-commit:
 
-- setup:
-  - Update to setuptools #27 ([c0d3b0d](https://github.com/imAsparky/cookiecutter-py3-package/commit/c0d3b0dc18a58a947a2d9eea5123a31ae39e843c)) ([#33](https://github.com/imAsparky/cookiecutter-py3-package/pull/33))
+    -   Weekly pre-commit autoupdate (#52) ([1cec5ce](https://github.com/imAsparky/cookiecutter-py3-package/commit/1cec5ce9c4db54a2945690906ead6a3f4fd1f420)) ([#52](https://github.com/imAsparky/cookiecutter-py3-package/pull/52))
 
-- Travis:
-  - Remove support for Travis #18 ([ade1959](https://github.com/imAsparky/cookiecutter-py3-package/commit/ade1959381459abb179df2b3a7c1e25ae695f3db)) ([#23](https://github.com/imAsparky/cookiecutter-py3-package/pull/23))
-  - Remove support #18 ([aa463f4](https://github.com/imAsparky/cookiecutter-py3-package/commit/aa463f412f26a03a9c1cc278b9bca56e54f114a2)) ([#21](https://github.com/imAsparky/cookiecutter-py3-package/pull/21))
+-   git:
 
-- README:
-  - Remove stale Similar Templates #11 ([2b62df5](https://github.com/imAsparky/cookiecutter-py3-package/commit/2b62df5f7cf28f6b10fcc17ecebc6dec6dd550e2))
+    -   Add vscode workspace folder .gitignore ([c000227](https://github.com/imAsparky/cookiecutter-py3-package/commit/c00022746f83c123ec441bdd010fdd06e8f34b58))
+    -   Add project folders to .gitignore ([4847e57](https://github.com/imAsparky/cookiecutter-py3-package/commit/4847e574c6b978a3aab14313b12a74d1c879dcd6))
 
-- docs:
-  - Comment on:push out for CHANGELOG ([ce7b075](https://github.com/imAsparky/cookiecutter-py3-package/commit/ce7b075187b060ca036e34a65f7f8e52a4ab1f0d))
+-   setup:
 
-- test:
-  - Rename workflow #10 ([d4a709b](https://github.com/imAsparky/cookiecutter-py3-package/commit/d4a709bcc6f8a431363b1837c3e78a6718f0ec44))
-  - Fix typo in jobs:name:  #10 ([38f6a89](https://github.com/imAsparky/cookiecutter-py3-package/commit/38f6a89d02b3512f143b6e74b775b8cdbaa2882a))
-  - Add test coverage Py39 Py3-10 #7 ([a7a9219](https://github.com/imAsparky/cookiecutter-py3-package/commit/a7a921961c2d439ac0724fc539249520f73c6c72))
+    -   Update to setuptools #27 ([c0d3b0d](https://github.com/imAsparky/cookiecutter-py3-package/commit/c0d3b0dc18a58a947a2d9eea5123a31ae39e843c)) ([#33](https://github.com/imAsparky/cookiecutter-py3-package/pull/33))
+
+-   Travis:
+
+    -   Remove support for Travis #18 ([ade1959](https://github.com/imAsparky/cookiecutter-py3-package/commit/ade1959381459abb179df2b3a7c1e25ae695f3db)) ([#23](https://github.com/imAsparky/cookiecutter-py3-package/pull/23))
+    -   Remove support #18 ([aa463f4](https://github.com/imAsparky/cookiecutter-py3-package/commit/aa463f412f26a03a9c1cc278b9bca56e54f114a2)) ([#21](https://github.com/imAsparky/cookiecutter-py3-package/pull/21))
+
+-   README:
+
+    -   Remove stale Similar Templates #11 ([2b62df5](https://github.com/imAsparky/cookiecutter-py3-package/commit/2b62df5f7cf28f6b10fcc17ecebc6dec6dd550e2))
+
+-   docs:
+
+    -   Comment on:push out for CHANGELOG ([ce7b075](https://github.com/imAsparky/cookiecutter-py3-package/commit/ce7b075187b060ca036e34a65f7f8e52a4ab1f0d))
+
+-   test:
+    -   Rename workflow #10 ([d4a709b](https://github.com/imAsparky/cookiecutter-py3-package/commit/d4a709bcc6f8a431363b1837c3e78a6718f0ec44))
+    -   Fix typo in jobs:name: #10 ([38f6a89](https://github.com/imAsparky/cookiecutter-py3-package/commit/38f6a89d02b3512f143b6e74b775b8cdbaa2882a))
+    -   Add test coverage Py39 Py3-10 #7 ([a7a9219](https://github.com/imAsparky/cookiecutter-py3-package/commit/a7a921961c2d439ac0724fc539249520f73c6c72))
 
 ### Documentation
 
-- codes:
-  - Add code of conduct #56 (#58) ([b69c126](https://github.com/imAsparky/cookiecutter-py3-package/commit/b69c1269178d77cee55983992b5a22737197d8b9)) ([#58](https://github.com/imAsparky/cookiecutter-py3-package/pull/58))
+-   codes:
 
-- README:
-  - Add pre-commit badge #54 (#55) ([08450af](https://github.com/imAsparky/cookiecutter-py3-package/commit/08450af653d7b175a0327f51e5aaac7643f422c0)) ([#55](https://github.com/imAsparky/cookiecutter-py3-package/pull/55))
-  - Add to list of notable changes (#24) ([5db0139](https://github.com/imAsparky/cookiecutter-py3-package/commit/5db0139e3c21190b3d2085d3c4947beeac2fea25)) ([#24](https://github.com/imAsparky/cookiecutter-py3-package/pull/24))
-  - Remove support for Travis CI #18 ([0dd88fa](https://github.com/imAsparky/cookiecutter-py3-package/commit/0dd88fa56d5646caddd54828a2640fa96379d0af))
-  - Update to reflect this fork #4 ([e592c57](https://github.com/imAsparky/cookiecutter-py3-package/commit/e592c5750e36aff5b8486e0324e8778510498d7c))
+    -   Add code of conduct #56 (#58) ([b69c126](https://github.com/imAsparky/cookiecutter-py3-package/commit/b69c1269178d77cee55983992b5a22737197d8b9)) ([#58](https://github.com/imAsparky/cookiecutter-py3-package/pull/58))
 
-- tutorial:
-  - Fix broken pypi checklist link #37 (#53) ([f6ec351](https://github.com/imAsparky/cookiecutter-py3-package/commit/f6ec3518368078b34d25293494b3332027ccb37b)) ([#53](https://github.com/imAsparky/cookiecutter-py3-package/pull/53))
+-   README:
 
-- logo:
-  - Create and add logo to README #38 (#41) ([0ca1adb](https://github.com/imAsparky/cookiecutter-py3-package/commit/0ca1adb6181138de7b6ccf06fa5984d2c693a169)) ([#41](https://github.com/imAsparky/cookiecutter-py3-package/pull/41))
+    -   Add pre-commit badge #54 (#55) ([08450af](https://github.com/imAsparky/cookiecutter-py3-package/commit/08450af653d7b175a0327f51e5aaac7643f422c0)) ([#55](https://github.com/imAsparky/cookiecutter-py3-package/pull/55))
+    -   Add to list of notable changes (#24) ([5db0139](https://github.com/imAsparky/cookiecutter-py3-package/commit/5db0139e3c21190b3d2085d3c4947beeac2fea25)) ([#24](https://github.com/imAsparky/cookiecutter-py3-package/pull/24))
+    -   Remove support for Travis CI #18 ([0dd88fa](https://github.com/imAsparky/cookiecutter-py3-package/commit/0dd88fa56d5646caddd54828a2640fa96379d0af))
+    -   Update to reflect this fork #4 ([e592c57](https://github.com/imAsparky/cookiecutter-py3-package/commit/e592c5750e36aff5b8486e0324e8778510498d7c))
 
-- update:
-  - Links->cookiecutter-py3-package #20 (#39) ([7522aa4](https://github.com/imAsparky/cookiecutter-py3-package/commit/7522aa4014eda677ec28bbd8154906f69afa8811)) ([#39](https://github.com/imAsparky/cookiecutter-py3-package/pull/39))
+-   tutorial:
 
-- structure:
-  - Update to newer sphinx style #34 ([6f76c4e](https://github.com/imAsparky/cookiecutter-py3-package/commit/6f76c4ead0bb70be7f9630a0fb12ab8f6297bf7d)) ([#35](https://github.com/imAsparky/cookiecutter-py3-package/pull/35))
+    -   Fix broken pypi checklist link #37 (#53) ([f6ec351](https://github.com/imAsparky/cookiecutter-py3-package/commit/f6ec3518368078b34d25293494b3332027ccb37b)) ([#53](https://github.com/imAsparky/cookiecutter-py3-package/pull/53))
 
-- fork:
-  - Update to indicate this fork #20 ([f287b06](https://github.com/imAsparky/cookiecutter-py3-package/commit/f287b06c8bf40262728bfe2dfe5d542200d0b2ba))
+-   logo:
+
+    -   Create and add logo to README #38 (#41) ([0ca1adb](https://github.com/imAsparky/cookiecutter-py3-package/commit/0ca1adb6181138de7b6ccf06fa5984d2c693a169)) ([#41](https://github.com/imAsparky/cookiecutter-py3-package/pull/41))
+
+-   update:
+
+    -   Links->cookiecutter-py3-package #20 (#39) ([7522aa4](https://github.com/imAsparky/cookiecutter-py3-package/commit/7522aa4014eda677ec28bbd8154906f69afa8811)) ([#39](https://github.com/imAsparky/cookiecutter-py3-package/pull/39))
+
+-   structure:
+
+    -   Update to newer sphinx style #34 ([6f76c4e](https://github.com/imAsparky/cookiecutter-py3-package/commit/6f76c4ead0bb70be7f9630a0fb12ab8f6297bf7d)) ([#35](https://github.com/imAsparky/cookiecutter-py3-package/pull/35))
+
+-   fork:
+    -   Update to indicate this fork #20 ([f287b06](https://github.com/imAsparky/cookiecutter-py3-package/commit/f287b06c8bf40262728bfe2dfe5d542200d0b2ba))
 
 ### Feature
 
-- package:
-  - Add Conventional commits msg #15 (#59) ([9ce47dc](https://github.com/imAsparky/cookiecutter-py3-package/commit/9ce47dc73327bdb39d49e5e2074f1320e71d2285)) ([#59](https://github.com/imAsparky/cookiecutter-py3-package/pull/59))
+-   package:
 
-- pre-commit:
-  - Add to pre-commit to GH #31 ([bf25e6c](https://github.com/imAsparky/cookiecutter-py3-package/commit/bf25e6cf327670a6e7a38e1464de74a25e447205)) ([#32](https://github.com/imAsparky/cookiecutter-py3-package/pull/32))
+    -   Add Conventional commits msg #15 (#59) ([9ce47dc](https://github.com/imAsparky/cookiecutter-py3-package/commit/9ce47dc73327bdb39d49e5e2074f1320e71d2285)) ([#59](https://github.com/imAsparky/cookiecutter-py3-package/pull/59))
 
-- test:
-  - Add GH action to test all contribs #10 ([9f0787d](https://github.com/imAsparky/cookiecutter-py3-package/commit/9f0787d7403429186948a38e4b33a1ea8c66ab71))
+-   pre-commit:
 
-- docs:
-  - Add automatic changelog #8 ([d14487a](https://github.com/imAsparky/cookiecutter-py3-package/commit/d14487aa3f3c190a1720884e1c875bdca055cb7d))
-  - Add automatic changelog #8 ([0160b52](https://github.com/imAsparky/cookiecutter-py3-package/commit/0160b52a0a623cc48c8400a5700b1a7460cb6812))
+    -   Add to pre-commit to GH #31 ([bf25e6c](https://github.com/imAsparky/cookiecutter-py3-package/commit/bf25e6cf327670a6e7a38e1464de74a25e447205)) ([#32](https://github.com/imAsparky/cookiecutter-py3-package/pull/32))
 
-- quality:
-  - Add code quality scan and badge #5 ([fb8fe81](https://github.com/imAsparky/cookiecutter-py3-package/commit/fb8fe81f4d9439e78a33b00babfa2ab3a7ae380b))
+-   test:
 
-- git:
-  - Add pre-commit and sane tests #3 ([83a8804](https://github.com/imAsparky/cookiecutter-py3-package/commit/83a88044bfb0ce44e54eb05943f2eb2c4282d195))
-  - Add conventional commits template #2 ([d808d8e](https://github.com/imAsparky/cookiecutter-py3-package/commit/d808d8ef08ca158f98bf5a302062f13ab503ab31))
-  - Add additional issue templates #1 ([6f5c9da](https://github.com/imAsparky/cookiecutter-py3-package/commit/6f5c9da926b158d2116db2cee3f1bf3ac459c86b))
+    -   Add GH action to test all contribs #10 ([9f0787d](https://github.com/imAsparky/cookiecutter-py3-package/commit/9f0787d7403429186948a38e4b33a1ea8c66ab71))
+
+-   docs:
+
+    -   Add automatic changelog #8 ([d14487a](https://github.com/imAsparky/cookiecutter-py3-package/commit/d14487aa3f3c190a1720884e1c875bdca055cb7d))
+    -   Add automatic changelog #8 ([0160b52](https://github.com/imAsparky/cookiecutter-py3-package/commit/0160b52a0a623cc48c8400a5700b1a7460cb6812))
+
+-   quality:
+
+    -   Add code quality scan and badge #5 ([fb8fe81](https://github.com/imAsparky/cookiecutter-py3-package/commit/fb8fe81f4d9439e78a33b00babfa2ab3a7ae380b))
+
+-   git:
+    -   Add pre-commit and sane tests #3 ([83a8804](https://github.com/imAsparky/cookiecutter-py3-package/commit/83a88044bfb0ce44e54eb05943f2eb2c4282d195))
+    -   Add conventional commits template #2 ([d808d8e](https://github.com/imAsparky/cookiecutter-py3-package/commit/d808d8ef08ca158f98bf5a302062f13ab503ab31))
+    -   Add additional issue templates #1 ([6f5c9da](https://github.com/imAsparky/cookiecutter-py3-package/commit/6f5c9da926b158d2116db2cee3f1bf3ac459c86b))
 
 ### Bug Fixes
 
-- version:
-  - Add a pre-tested if: condition #60 (#67) ([d227bea](https://github.com/imAsparky/cookiecutter-py3-package/commit/d227bea0eca9b5239438ff61491c2559f6b440c0)) ([#67](https://github.com/imAsparky/cookiecutter-py3-package/pull/67))
-  - Del manual job & fix concurrency #60  (#66) ([6e1c1ca](https://github.com/imAsparky/cookiecutter-py3-package/commit/6e1c1cadbe20755efb1911768343e6050a293469)) ([#66](https://github.com/imAsparky/cookiecutter-py3-package/pull/66))
-  - change to chk_bld_stat false #60 (#63) ([cc63fa9](https://github.com/imAsparky/cookiecutter-py3-package/commit/cc63fa996a00e52c4c91ffcc55eb3056fe1c678f)) ([#63](https://github.com/imAsparky/cookiecutter-py3-package/pull/63))
-  - Change to python-semantic-release #60  (#62) ([83d8d06](https://github.com/imAsparky/cookiecutter-py3-package/commit/83d8d06ef0f0bee22dc90e4abd32e26ba21bcba6)) ([#62](https://github.com/imAsparky/cookiecutter-py3-package/pull/62))
-  - Change to python-semantic-release #60 (#61) ([88c55f3](https://github.com/imAsparky/cookiecutter-py3-package/commit/88c55f3755993a9a2a459d9ae367fa39b81fea50)) ([#61](https://github.com/imAsparky/cookiecutter-py3-package/pull/61))
+-   version:
 
-- pre-com:
-  - Fix pre-commit errors #50  (#51) ([9360c7f](https://github.com/imAsparky/cookiecutter-py3-package/commit/9360c7fe47a3e79ae421c5e43ce330414203b2b1)) ([#51](https://github.com/imAsparky/cookiecutter-py3-package/pull/51))
+    -   Add a pre-tested if: condition #60 (#67) ([d227bea](https://github.com/imAsparky/cookiecutter-py3-package/commit/d227bea0eca9b5239438ff61491c2559f6b440c0)) ([#67](https://github.com/imAsparky/cookiecutter-py3-package/pull/67))
+    -   Del manual job & fix concurrency #60 (#66) ([6e1c1ca](https://github.com/imAsparky/cookiecutter-py3-package/commit/6e1c1cadbe20755efb1911768343e6050a293469)) ([#66](https://github.com/imAsparky/cookiecutter-py3-package/pull/66))
+    -   change to chk_bld_stat false #60 (#63) ([cc63fa9](https://github.com/imAsparky/cookiecutter-py3-package/commit/cc63fa996a00e52c4c91ffcc55eb3056fe1c678f)) ([#63](https://github.com/imAsparky/cookiecutter-py3-package/pull/63))
+    -   Change to python-semantic-release #60 (#62) ([83d8d06](https://github.com/imAsparky/cookiecutter-py3-package/commit/83d8d06ef0f0bee22dc90e4abd32e26ba21bcba6)) ([#62](https://github.com/imAsparky/cookiecutter-py3-package/pull/62))
+    -   Change to python-semantic-release #60 (#61) ([88c55f3](https://github.com/imAsparky/cookiecutter-py3-package/commit/88c55f3755993a9a2a459d9ae367fa39b81fea50)) ([#61](https://github.com/imAsparky/cookiecutter-py3-package/pull/61))
 
-- CHANGELOG:
-  - Fix tox.ini and conf.py #43 (#47) ([c7ead74](https://github.com/imAsparky/cookiecutter-py3-package/commit/c7ead747409c6b1997e2524fefd261f7259d0274)) ([#47](https://github.com/imAsparky/cookiecutter-py3-package/pull/47))
+-   pre-com:
 
-- git:
-  - Comment out on:push:main  #44 (#45) ([3631126](https://github.com/imAsparky/cookiecutter-py3-package/commit/3631126832b3724859a2cfb58a834205c5948567)) ([#45](https://github.com/imAsparky/cookiecutter-py3-package/pull/45))
-  - Remove test for py3.10 #26 ([e5fdef2](https://github.com/imAsparky/cookiecutter-py3-package/commit/e5fdef216b7adf4c0759d85fc2b90a733d2f4426))
+    -   Fix pre-commit errors #50 (#51) ([9360c7f](https://github.com/imAsparky/cookiecutter-py3-package/commit/9360c7fe47a3e79ae421c5e43ce330414203b2b1)) ([#51](https://github.com/imAsparky/cookiecutter-py3-package/pull/51))
 
-- docs:
-  - Add readthedocs.yaml config file #40 (#42) ([bc14391](https://github.com/imAsparky/cookiecutter-py3-package/commit/bc14391f508c585aa8a29f00150c75e4823bc4a0)) ([#42](https://github.com/imAsparky/cookiecutter-py3-package/pull/42))
+-   CHANGELOG:
 
-\* *This CHANGELOG was automatically generated by [auto-generate-changelog](https://github.com/BobAnkh/auto-generate-changelog)*
+    -   Fix tox.ini and conf.py #43 (#47) ([c7ead74](https://github.com/imAsparky/cookiecutter-py3-package/commit/c7ead747409c6b1997e2524fefd261f7259d0274)) ([#47](https://github.com/imAsparky/cookiecutter-py3-package/pull/47))
+
+-   git:
+
+    -   Comment out on:push:main #44 (#45) ([3631126](https://github.com/imAsparky/cookiecutter-py3-package/commit/3631126832b3724859a2cfb58a834205c5948567)) ([#45](https://github.com/imAsparky/cookiecutter-py3-package/pull/45))
+    -   Remove test for py3.10 #26 ([e5fdef2](https://github.com/imAsparky/cookiecutter-py3-package/commit/e5fdef216b7adf4c0759d85fc2b90a733d2f4426))
+
+-   docs:
+    -   Add readthedocs.yaml config file #40 (#42) ([bc14391](https://github.com/imAsparky/cookiecutter-py3-package/commit/bc14391f508c585aa8a29f00150c75e4823bc4a0)) ([#42](https://github.com/imAsparky/cookiecutter-py3-package/pull/42))
+
+\* _This CHANGELOG was automatically generated by [auto-generate-changelog](https://github.com/BobAnkh/auto-generate-changelog)_

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,6 +18,7 @@
   "create_auto_CHANGELOG": "y",
   "github_CHANGELOG_access_token": ["secrets.GITHUB_TOKEN", "secrets.CHANGELOG_UPDATE"],
   "use_GH_action_semantic_version": "y",
+  "use_GH_custom_issue_templates": "y",
   "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"],
   "_copy_without_render": [
         ".github/workflows/test_contribution.yaml",

--- a/docs/source/prompts.rst
+++ b/docs/source/prompts.rst
@@ -144,6 +144,38 @@ project.
   A GitHub PAT is required, and the repository secret is named `SEM_VER`
   for this feature to work.
 
+**use_GH_custom_issue_templates**
+  *default = y*
+
+  Four custom GitHub issue templates for your package:
+
+  #. bug-report.md
+  #. chore.md
+  #. documentation-request.md
+  #. feature-request.md
+
+  The custom issue templates prompt users to help provide enough information
+  in a templated format.
+
+  The default assignee is you; however, re-assign if required at creation
+  time or any time after.
+
+  See the critical template markdown file settings below for a feature request.
+
+.. code-block:: yaml
+
+    ---
+    name: Feature request
+    about: Suggest an idea for this project
+    title: "[FEAT]:"
+    labels: enhancement
+    assignees: { { cookiecutter.github_username } }
+    ---
+
+| If you prefer, a simple issue template is available for use with all
+  issues if you choose `no` for this feature.
+
+
 **open_source_license**
     *default = MIT*
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -7,7 +7,8 @@ PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
 
 def remove_file(filepath):
     """Remove files not required for this generated python package."""
-    os.remove(os.path.join(PROJECT_DIRECTORY, filepath))
+    if os.path.exists(os.path.join(PROJECT_DIRECTORY, filepath)):
+        os.remove(os.path.join(PROJECT_DIRECTORY, filepath))
 
 
 if __name__ == "__main__":
@@ -39,3 +40,12 @@ if __name__ == "__main__":
     if "{{ cookiecutter.use_GH_action_semantic_version }}" != "y":
         remove_file(".github/workflows/semantic_release.yaml")
         remove_file(".github/semantic.yaml")
+
+    if "{{ cookiecutter.use_GH_custom_issue_templates }}" != "y":
+        remove_file(".github/ISSUE_TEMPLATE/bug-report.md")
+        remove_file(".github/ISSUE_TEMPLATE/chore.md")
+        remove_file(".github/ISSUE_TEMPLATE/documentation-request.md")
+        remove_file(".github/ISSUE_TEMPLATE/feature-request.md")
+
+    if "{{ cookiecutter.use_GH_custom_issue_templates }}" == "y":
+        remove_file(".github/ISSUE_TEMPLATE.md")

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -476,3 +476,49 @@ def test_bake_without_auto_semantic_version(cookies):
             f.basename for f in result.project.join(".github/workflows").listdir()
         ]
         assert "semantic_release.yaml" not in sem_ver_workflow_without_files
+
+
+def test_bake_with_custom_issue_templates(cookies):
+    """
+    Test cookiecutter created the package with custom issue templates.
+    """
+    with bake_in_temp_dir(
+        cookies, extra_context={"use_GH_custom_issue_templates": "y"}
+    ) as result:
+
+        templates_with_files = [
+            f.basename for f in result.project.join(".github/ISSUE_TEMPLATE").listdir()
+        ]
+        assert "bug-report.md" in templates_with_files
+        assert "chore.md" in templates_with_files
+        assert "documentation-request.md" in templates_with_files
+        assert "feature-request.md" in templates_with_files
+
+        # Test the standard template has been removed.
+        standard_issue_template = [
+            f.basename for f in result.project.join(".github/").listdir()
+        ]
+        assert "ISSUE_TEMPLATE.md" not in standard_issue_template
+
+
+def test_bake_without_custom_issue_templates(cookies):
+    """
+    Test cookiecutter created the package without custom issue templates.
+    """
+    with bake_in_temp_dir(
+        cookies, extra_context={"use_GH_custom_issue_templates": "n"}
+    ) as result:
+
+        templates_without_files = [
+            f.basename for f in result.project.join(".github/ISSUE_TEMPLATE").listdir()
+        ]
+        assert "bug-report.md" not in templates_without_files
+        assert "chore.md" not in templates_without_files
+        assert "documentation-request.md" not in templates_without_files
+        assert "feature-request.md" not in templates_without_files
+
+        # Test the standard template has been removed.
+        standard_issue_template = [
+            f.basename for f in result.project.join(".github/").listdir()
+        ]
+        assert "ISSUE_TEMPLATE.md" in standard_issue_template

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]:"
+labels: bug
+assignees: { { cookiecutter.github_username } }
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+
+-   **{{ cookiecutter.project_name }} version:**
+-   Python version:
+-   OS: [e.g. iOS]
+-   Browser [e.g. chrome, safari]
+-   Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+
+-   Device: [e.g. iPhone6]
+-   OS: [e.g. iOS8.1]
+-   Browser [e.g. stock browser, safari]
+-   Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/chore.md
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,9 @@
+---
+name: Chore
+about: A Chore that needs to be done
+title: "[CHORE]:"
+labels: chore
+assignees: { { cookiecutter.github_username } }
+---
+
+**What is the chore?**

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -1,0 +1,13 @@
+---
+name: Documentation request
+about: Suggest documentaton for this project
+title: "[DOCS]:"
+labels: documentation
+assignees: { { cookiecutter.github_username } }
+---
+
+**Describe alternatives you've considered**
+Would you please share your clear and concise description of any alternative/similar documentation you've considered.
+
+**Additional context**
+Would you please share any other context or screenshots about the documentation request here.

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEAT]:"
+labels: enhancement
+assignees: { { cookiecutter.github_username } }
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
* A standard-issue template existed with minimal templating.
* Additional templates will prompt the user for information that suits
  the issue type.

closes #75