### PR TITLE
docs(git): Notes to alert of a git version bug #112

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,11 @@ Features
    Conventional-Commits_ style git commit message template, cookiecutter
    will simultaneously add it to your local git config file.
 
+.. note::
+
+   Initialise your local git requires Git v2.33.0 or above. A bug report has
+   been raised and a fix is coming.
+
 .. _Cookiecutter: https://github.com/cookiecutter/cookiecutter
 .. _cookiecutter-pypackage: https://github.com/audreyfeldroy/cookiecutter-pypackage
 .. _Projects: https://github.com/imAsparky/cookiecutter-py3-package/projects

--- a/docs/source/prompts.rst
+++ b/docs/source/prompts.rst
@@ -203,6 +203,34 @@ project.
   Selecting this option also includes automatically adding the conventional
   commits message template to git config if you have chosen that option.
 
+  **Initialise your local git requires Git v2.33.0 or above. A bug report has
+  been raised and a fix is coming.**
+
+
+**use_release_to_test_pypi_with_tags**
+   *default = n*
+
+   Selecting this option will configure a workflow to simulate a production
+   test and then release to PyPi; however, the release will go to the Test
+   PyPi index.
+   This feature is helpful to help iron out any bugs before releasing your
+   package into the  PyPi index.
+   To use this feature, tag with 'dev*' before pushing to the repository.
+   The `dev` tag will trigger the workflow.
+
+   See the example tags below
+
+.. code-block:: bash
+
+    git tag dev
+    git tag dev-new-feature
+    git tag dev-testing-some-update
+
+.. note::
+
+    Perhaps using semantic version below version 1.0.0 could
+    be one way to use the test PyPi releases.
+
 
 **open_source_license**
     *default = MIT*


### PR DESCRIPTION
Alert users that the auto git init feature requires git v2.33.0 or above
and a fix is on the way.

WIP #112