### PR TITLE
docs(cookie): Fix typo in create-github-repo tutorial #147

### DIFF
--- a/docs/source/tutorials/tutorial-create-GH-repo.rst
+++ b/docs/source/tutorials/tutorial-create-GH-repo.rst
@@ -65,7 +65,7 @@ Click `Create Repository`.
 New Repository Command Line Options
 -----------------------------------
 
-After clicking `Create Repsotory` you will be presented with these options.
+After clicking `Create Repository` you will be presented with these options.
 
 .. image:: ../_static/imgs/tutorials/new-repo-cli-options.png
     :alt: New Repository Command Line Options


### PR DESCRIPTION
Change Repsitory to Repository.

closes #147